### PR TITLE
Automatically update prize points + minor changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ process and cuts down the total process by 10-20 minutes to <1 minute everytime.
 * Supports an unlimited amount of groups from 4-person to 7-person groups
 * Supports backtracking in case you input the wrong value or make a mistake (might be buggy in some cases)
 * Authenticates based upon if you have the necessary permissions and caches your credentials if they're valid
-* Automatically does calculations for rating changes, match winners, table winners, and school year and semester
+* Automatically does calculations for rating changes, match winners, table winners, league points, and school year and semester
 * Automatically generates a new year folder if no semester folders exist for that year yet
 * Automatically generates a new semester folder if no league sheets exist for that semester folder yet
 * Automatically uploads the league sheet to the relevant folders (year, semester) in the Google Drive if they exist

--- a/config.py
+++ b/config.py
@@ -1,10 +1,12 @@
 TEST_ENV = {
 	'ratings_spreadsheet_id': '1vE4qVg1_FP_vAknI2pr8-Z97aV9ZTYqDHqq2Hy6Ydi0',
+	'prize_points_spreadsheet_id': '1lt96GC-ld7PwGhus0MZ8E9Vr_EVWgch3jFIfnF7tUyg',
 	'results_folder_id': '1EfvFgtENNJ4LdY4FqGtJrYUbPfppm3C9'
 }
 
 LIVE_ENV = {
 	'ratings_spreadsheet_id': '1TzyleWIfON1ADruZxtbq8Xq0fl-HEHNgJakBVZ6WxqY',
+	'prize_points_spreadsheet_id': '1wwG1F6M1fLDgs1yyAbp0cXKF-VviFeI7t4JNhYPqHXs',
 	'results_folder_id': '0B9Mt_sNXCmNzbTVici1WYk1tcmc'
 }
 

--- a/excel_functions.py
+++ b/excel_functions.py
@@ -260,15 +260,6 @@ class ResultSheet:
         self.match_list = []
 
     def get_match_winner(self, matches):
-        # most_matches_won = max(self.group.sorted_players, key=lambda player: player.matches_won).matches_won
-        # players_most_matches = list(filter(lambda player: player.matches_won == most_matches_won,
-        #                                    self.group.sorted_players))
-        # most_games_won = max(players_most_matches, key=lambda player: player.games_won).games_won
-        # players_most_matches_games = list(filter(lambda player: player.games_won == most_games_won,
-        #                                        players_most_matches))
-        # match_winner = sorted(players_most_matches_games, key=lambda player: player.final_rating)[-1]
-        # return match_winner
-
         #Sort by matches won, ties broken with games won
         match_winner_groups = []
         sort_match_winner = sorted(self.group.sorted_players, key=lambda player: player.games_won, reverse=True)

--- a/google_sheets_functions.py
+++ b/google_sheets_functions.py
@@ -5,6 +5,8 @@ from tabulate import tabulate
 import shared_functions
 import httplib2
 import config
+from collections import defaultdict
+import xlsxwriter
 
 # If modifying these scopes, delete your previously saved credentials
 # at ~/.credentials/sheets_client_secret.json
@@ -15,6 +17,7 @@ CACHE_FILE_NAME = 'sheets-api.json'
 
 # Defaults to test env. If you want to use live env, go to config and set CURRENT_ENV = LIVE_ENV
 RATINGS_SPREADSHEET_ID = config.CURRENT_ENV['ratings_spreadsheet_id']
+PRIZE_POINTS_SPREADSHEET_ID = config.CURRENT_ENV['prize_points_spreadsheet_id']
 
 def create_service():
     credentials = shared_functions.get_credentials(cache_file_name=CACHE_FILE_NAME,
@@ -25,17 +28,17 @@ def create_service():
     service = discovery.build('sheets', 'v4', http=http, discoveryServiceUrl=discoveryUrl)
     return service
 
-def get_sheets(service):
+def get_sheets(service, spreadsheet_id):
     try:
         result = service.spreadsheets().get(
-            spreadsheetId=RATINGS_SPREADSHEET_ID).execute()
+            spreadsheetId=spreadsheet_id).execute()
         return [sheet for sheet in result['sheets']]
     except errors.HttpError:
         print("You don't have permission to access these files.")
         shared_functions.remove_file_from_cache(CACHE_FILE_NAME)
 
 def get_ratings_sheet_info(service, sheet_name):
-    sheets = get_sheets(service)
+    sheets = get_sheets(service, RATINGS_SPREADSHEET_ID)
     sheet_names = [sheet['properties']['title'] for sheet in sheets]
     if sheet_name in sheet_names:
         range = '{}!A2:C'.format(sheet_name)
@@ -215,6 +218,20 @@ def generate_ratings_sheet(service, sheet_name):
                     'sheetId': new_sheet_id,
                     'dimension': 'ROWS',
                     'startIndex': 0,
+                    'endIndex': 1
+                },
+                'properties': {
+                    'pixelSize': 40
+                },
+                'fields': 'pixelSize'
+            }
+        },
+        {
+            'updateDimensionProperties': {
+                'range': {
+                    'sheetId': new_sheet_id,
+                    'dimension': 'ROWS',
+                    'startIndex': 2,
                     'endIndex': 3
                 },
                 'properties': {
@@ -252,15 +269,15 @@ def generate_ratings_sheet(service, sheet_name):
         body=adjust_len_width_body
     ).execute()
 
-def get_sheet_id(service, sheet_name):
-    sheets = get_sheets(service)
+def get_sheet_id(service, spreadsheet_id, sheet_name):
+    sheets = get_sheets(service, spreadsheet_id)
     for sheet in sheets:
         if sheet['properties']['title'] == sheet_name:
             return sheet['properties']['sheetId']
     return None
 
 def write_to_ratings_sheet(service, row_data, start_row_index, end_row_index, sheet_name):
-    sheet_id = get_sheet_id(service, sheet_name)
+    sheet_id = get_sheet_id(service, RATINGS_SPREADSHEET_ID, sheet_name)
 
     write_body = {
         'majorDimension': 'ROWS',
@@ -377,4 +394,275 @@ def write_to_ratings_sheet(service, row_data, start_row_index, end_row_index, sh
     service.spreadsheets().batchUpdate(
         spreadsheetId=RATINGS_SPREADSHEET_ID,
         body=update_border_body
+    ).execute()
+
+def get_prize_points_sheet_info(service, sheet_name):
+    sheets = get_sheets(service, PRIZE_POINTS_SPREADSHEET_ID)
+    sheet_names = [sheet['properties']['title'] for sheet in sheets]
+    if sheet_name in sheet_names:
+        range = '{}!1:2'.format(sheet_name)
+        result = service.spreadsheets().values().get(
+            spreadsheetId=PRIZE_POINTS_SPREADSHEET_ID, range=range, majorDimension='COLUMNS').execute()
+        numLeagues = len(result.get('values', []))-4
+        range = '{}!A1:'.format(sheet_name)+xlsxwriter.utility.xl_col_to_name(numLeagues+4)
+        result = service.spreadsheets().values().get(
+            spreadsheetId=PRIZE_POINTS_SPREADSHEET_ID, range=range, majorDimension='ROWS').execute()
+        values = result.get('values', [])
+        if not values:
+            print('No prize points found for this semester.')
+        else:
+            print('Prize points detected.\n')
+            return values, numLeagues
+    else:
+        print('No prize points found for this semester.')
+        generate_prize_points_sheet(service, sheet_name)
+    return None, 0
+
+def get_prize_points(service, prize_points_sheet_name):
+    prize_points, numLeagues = get_prize_points_sheet_info(service, prize_points_sheet_name)
+    prize_points_dict = defaultdict(dict)
+    points_used = {}
+    for i in range(1,numLeagues+1):
+        for j in range(1,len(prize_points)):
+            prize_points_dict[prize_points[0][3+i]][prize_points[j][0]] = prize_points[j][3+i]
+            points_used[prize_points[j][0]] = prize_points[j][2] if prize_points[j][2] != '' else 0
+    return prize_points_dict, points_used, numLeagues
+
+def generate_prize_points_sheet(service, sheet_name):
+    new_sheet_body = {
+        'requests': [
+            {
+                'addSheet': {
+                    'properties': {
+                        'title': sheet_name,
+                        'index': 0
+                    }
+                }
+            },
+        ]
+    }
+    add_sheet = service.spreadsheets().batchUpdate(spreadsheetId=PRIZE_POINTS_SPREADSHEET_ID, body=new_sheet_body).execute()
+    new_sheet_id = add_sheet['replies'][0]['addSheet']['properties']['sheetId']
+
+    update_headers_body = {
+        'majorDimension': 'ROWS',
+        'values': [
+            ['Name', 'Total earned', 'Total used', 'Total remaining']
+        ]
+    }
+
+    update_header_format = {
+        'requests': [{
+            'repeatCell': {
+                'range': {
+                    'sheetId': new_sheet_id,
+                    'startRowIndex': 0,
+                    'endRowIndex': 1,
+                    'startColumnIndex': 0,
+                    'endColumnIndex': 4
+                },
+                'cell': {
+                    'userEnteredFormat': {
+                        'horizontalAlignment': 'CENTER',
+                        'verticalAlignment': 'MIDDLE',
+                        'wrapStrategy': 'WRAP',
+                        'textFormat': {
+                            'fontSize': 10,
+                            'bold': True
+                        }
+                    }
+                },
+                'fields': 'userEnteredFormat(textFormat, '
+                          'horizontalAlignment, verticalAlignment, wrapStrategy)'
+            }
+        }]
+    }
+
+    update_frozen_column_body = {
+        'requests': [{
+            'updateSheetProperties': {
+                'properties': {
+                    'sheetId': new_sheet_id,
+                    'gridProperties': {
+                        'frozenColumnCount': 4
+                    }
+                },
+                'fields': 'gridProperties.frozenColumnCount'
+            }
+        }]
+    }
+
+    adjust_len_width_body = {
+        'requests': [{
+            'updateDimensionProperties': {
+                'range': {
+                    'sheetId': new_sheet_id,
+                    'dimension': 'COLUMNS',
+                    'startIndex': 0,
+                    'endIndex': 1
+                },
+                'properties': {
+                    'pixelSize': 180
+                },
+                'fields': 'pixelSize'
+            }
+        },
+        {
+            'updateDimensionProperties': {
+                'range': {
+                    'sheetId': new_sheet_id,
+                    'dimension': 'COLUMNS',
+                    'startIndex': 1,
+                    'endIndex': 4
+                },
+                'properties': {
+                    'pixelSize': 120
+                },
+                'fields': 'pixelSize'
+            }
+        },
+        {
+            'updateDimensionProperties': {
+                'range': {
+                    'sheetId': new_sheet_id,
+                    'dimension': 'ROWS',
+                    'startIndex': 0,
+                    'endIndex': 3
+                },
+                'properties': {
+                    'pixelSize': 30
+                },
+                'fields': 'pixelSize'
+            }
+        }]
+    }
+
+    service.spreadsheets().values().update(
+        spreadsheetId=PRIZE_POINTS_SPREADSHEET_ID,
+        range='{}!A1:D1'.format(sheet_name),
+        body=update_headers_body,
+        valueInputOption='USER_ENTERED'
+    ).execute()
+
+    service.spreadsheets().batchUpdate(
+        spreadsheetId=PRIZE_POINTS_SPREADSHEET_ID,
+        body=update_header_format
+    ).execute()
+
+    service.spreadsheets().batchUpdate(
+        spreadsheetId=PRIZE_POINTS_SPREADSHEET_ID,
+        body=update_frozen_column_body
+    ).execute()
+
+    service.spreadsheets().batchUpdate(
+        spreadsheetId=PRIZE_POINTS_SPREADSHEET_ID,
+        body=adjust_len_width_body
+    ).execute()
+
+def write_to_prize_points_sheet(service, roster, prize_points, points_used, num_leagues, start_row_index, end_row_index, sheet_name):
+    sheet_id = get_sheet_id(service, PRIZE_POINTS_SPREADSHEET_ID, sheet_name)
+    roster = sorted(roster)
+    
+    write_data = []
+    for i in prize_points.keys():
+        col_data = [i]
+        for j in roster:
+            if j in prize_points[i]:
+                col_data.append(prize_points[i][j])
+            else:
+                col_data.append(0)
+        write_data.append(col_data)
+
+    write_body = {
+        'majorDimension': 'COLUMNS',
+        'values': write_data
+    }
+
+    service.spreadsheets().values().update(
+        spreadsheetId=PRIZE_POINTS_SPREADSHEET_ID,
+        range='{}!E1:'.format(sheet_name)+xlsxwriter.utility.xl_col_to_name(num_leagues+4),
+        body=write_body,
+        valueInputOption='USER_ENTERED'
+    ).execute()
+
+    roster_rows = [[i] for i in roster]
+    roster_data = {
+        'majorDimension': 'ROWS',
+        'values': roster_rows
+    }
+
+    service.spreadsheets().values().update(
+        spreadsheetId=PRIZE_POINTS_SPREADSHEET_ID,
+        range='{}!A2'.format(sheet_name),
+        body=roster_data,
+        valueInputOption='USER_ENTERED'
+    ).execute()
+
+    formula = "=SUM(E2:"+xlsxwriter.utility.xl_col_to_name(num_leagues+4)+"2)"
+    total_points_formula = {
+        "requests": [{
+            "repeatCell": {
+                "range": {
+                    "sheetId": sheet_id,
+                    "startRowIndex": 1,
+                    "endRowIndex": len(roster)+1,
+                    "startColumnIndex": 1,
+                    "endColumnIndex": 2
+                },
+                "cell": {
+                    "userEnteredValue": {
+                        "formulaValue": formula
+                    }
+                },
+                "fields": "userEnteredValue"
+            }
+        }]
+    }
+
+    service.spreadsheets().batchUpdate(
+        spreadsheetId=PRIZE_POINTS_SPREADSHEET_ID,
+        body=total_points_formula
+    ).execute()
+
+    points_used_data = []
+    for j in roster:
+        if j in points_used:
+            points_used_data.append([points_used[j]])
+        else:
+            points_used_data.append([0])
+    points_used_body = {
+        'majorDimension': 'ROWS',
+        'values': points_used_data
+    }
+
+    service.spreadsheets().values().update(
+        spreadsheetId=PRIZE_POINTS_SPREADSHEET_ID,
+        range='{}!C2:D'.format(sheet_name),
+        body=points_used_body,
+        valueInputOption='USER_ENTERED'
+    ).execute()
+
+    total_remaining_formula = {
+        "requests": [{
+            "repeatCell": {
+                "range": {
+                    "sheetId": sheet_id,
+                    "startRowIndex": 1,
+                    "endRowIndex": len(roster)+1,
+                    "startColumnIndex": 3,
+                    "endColumnIndex": 4
+                },
+                "cell": {
+                    "userEnteredValue": {
+                        "formulaValue": "=B2-C2"
+                    }
+                },
+                "fields": "userEnteredValue"
+            }
+        }]
+    }
+
+    service.spreadsheets().batchUpdate(
+        spreadsheetId=PRIZE_POINTS_SPREADSHEET_ID,
+        body=total_remaining_formula
     ).execute()

--- a/google_sheets_functions.py
+++ b/google_sheets_functions.py
@@ -562,7 +562,7 @@ def generate_prize_points_sheet(service, sheet_name):
 def write_to_prize_points_sheet(service, roster, prize_points, points_used, num_leagues, start_row_index, end_row_index, sheet_name):
     sheet_id = get_sheet_id(service, PRIZE_POINTS_SPREADSHEET_ID, sheet_name)
     roster = sorted(roster)
-    
+
     write_data = []
     for i in prize_points.keys():
         col_data = [i]


### PR DESCRIPTION
Automatically update prize points:
- Update readme to include prize point functionality
- Add prize points spreadsheet IDs for live and test env in config.py
- Add functions in google_sheets_functions.py to read prize point spreadsheet, format, and write to prize point sheet
- Changes in excel_functions.py such that flow of code is as follow
    1.  read spreadsheet and get dictionary of league dates and prize points awarded
    2. use updated get_match_winner() to rank all players in a group instead of just the winner
         - ties are broken by games won, then head-to-head if two way or just accepted as a tie if >two way
         - in the case of a tie, prize points that would be awarded if it wasn't a tie are summed and then split evenly among players tied
    3. add to prize point dictionary current league date and points awarded
    4. write to spreadsheet 

Add 3 player groups in excel_functions.py
