### PR TITLE
fix(sort): remove sorting by adjusted rating

### DIFF
--- a/excel_functions.py
+++ b/excel_functions.py
@@ -451,13 +451,12 @@ class ResultSheet:
             # determine if ratings need to be adjusted and second pass needed
             if i == 0:
                 for player in self.group.sorted_players:
-                    if(player.rating_change >= 50):
+                    if player.rating_change >= 50:
                         player.player_rating[1] = player.final_rating
                     player.rating_change = 0
                     player.final_rating = player.player_rating[1]
                     player.matches_won = 0
                     player.games_won = 0
-                self.group.sort_ratings(1)
 
         for player in self.group.sorted_players:
             league_roster_dict[player.player_name] = player.final_rating
@@ -494,10 +493,10 @@ class SummarySheet:
     def create_title_info(self):
         description = 'Group winners (denoted by **) are promoted to the next higher table during the next week' \
                       ' if they are present.'
-        self.worksheet.merge_range(first_row=0, first_col=0, last_row=0, last_col=8,
+        self.worksheet.merge_range(first_row=0, first_col=1, last_row=0, last_col=8,
                                    data='League Summary - {}'.format(self.name),
                                    cell_format=self.summary_main_title_format)
-        self.worksheet.merge_range(first_row=2, first_col=2, last_row=3, last_col=6, data=description,
+        self.worksheet.merge_range(first_row=2, first_col=2, last_row=3, last_col=7, data=description,
                                    cell_format=self.summary_description_format)
 
     def make_table(self, title_row_num, header_row_num, group_num):
@@ -714,8 +713,8 @@ def set_up_workbook():
 
 def get_match_inputs(group, backtrack=False):
     print('-  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -\n')
-    print('Please input the game scores for {}.'.format(group.group_name))
-    print("\nFor example, assuming B won 3 - 2 for Match B vs D, input 3:2.")
+    print('Please input the game scores for {}.\n'.format(group.group_name))
+    print("For example, assuming B won 3 - 2 for Match B vs D, input 3:2.")
     print("In the case of B losing to D 2-3, input 2:3.\n")
 
     match_list = []
@@ -772,7 +771,7 @@ def generate_workbook():
     print('_______________________________________________________________________________')
     print("Basic rules for league at GTTTA:\n")
     print("There can be no more than seven players in any group.")
-    print("There can be no less than four people per group.")
+    print("There can be no less than three people per group.")
     print("Type 'back' or 'b' to go back at any time.")
     print("Type 'quit' or 'q' to exit the program at any time.\n")
 
@@ -790,7 +789,7 @@ def generate_workbook():
     ratings_sheet_name = get_ratings_sheet_name(file_name)
     league_roster_list, league_roster_dict = google_sheets_functions.get_league_roster(service, ratings_sheet_name)
     prize_points_sheet_name = get_prize_points_sheet_name(ratings_sheet_name)
-    prize_points_dict, points_used, numLeagues = google_sheets_functions.get_prize_points(service, prize_points_sheet_name)
+    prize_points_dict, points_used, num_leagues = google_sheets_functions.get_prize_points(service, prize_points_sheet_name)
     ratings_sheet_start_row_index = len(league_roster_dict) + 1
 
     group_index = 0
@@ -845,8 +844,8 @@ def generate_workbook():
         title_row_num = last_row_num + 2
         group_index += 1
 
-    print('_______________________________________________________________________________')
-    print('\nOpening league sheet...')
+    print('_______________________________________________________________________________\n')
+    print('Opening league sheet...')
 
     workbook.close()
     ratings_sheet_end_row_index = len(league_roster_dict) + 1
@@ -862,7 +861,7 @@ def generate_workbook():
     prize_points_dict[file_name[:-5]] = prize_points
     google_sheets_functions.write_to_prize_points_sheet(service=service, roster=league_roster_dict.keys(),
                                                         prize_points=prize_points_dict,
-                                                        points_used=points_used, num_leagues = numLeagues,
+                                                        points_used=points_used, num_leagues = num_leagues,
                                                         start_row_index=ratings_sheet_start_row_index,
                                                         end_row_index=ratings_sheet_end_row_index,
                                                         sheet_name=prize_points_sheet_name)

--- a/google_drive_functions.py
+++ b/google_drive_functions.py
@@ -10,7 +10,7 @@ from datetime import date as datetime_date
 from webbrowser import open
 
 # If modifying these scopes, delete your previously saved credentials
-# at ~/.credentials/drive_client_secret.json
+# at ~/.credentials/client_secret.json
 SCOPES = ['https://www.googleapis.com/auth/drive', 'https://www.googleapis.com/auth/spreadsheets']
 CLIENT_SECRET_FILE = 'client_secret.json'
 APPLICATION_NAME = 'TT Automation'

--- a/google_sheets_functions.py
+++ b/google_sheets_functions.py
@@ -429,7 +429,7 @@ def get_prize_points(service, prize_points_sheet_name):
         for row in range(1, len(prize_points)):
             league_date = prize_points[0][3 + col]
             name = prize_points[row][0]
-            points = prize_points[row][3 + col]
+            points = prize_points[row][3 + col] if len(prize_points[row]) < 3 + col else 0
             points_used = prize_points[row][2]
 
             prize_points_dict[league_date][name] = points

--- a/google_sheets_functions.py
+++ b/google_sheets_functions.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 import xlsxwriter
 
 # If modifying these scopes, delete your previously saved credentials
-# at ~/.credentials/sheets_client_secret.json
+# at ~/.credentials/client_secret.json
 SCOPES = ['https://www.googleapis.com/auth/drive', 'https://www.googleapis.com/auth/spreadsheets']
 CLIENT_SECRET_FILE = 'client_secret.json'
 APPLICATION_NAME = 'TT Automation'
@@ -400,33 +400,42 @@ def get_prize_points_sheet_info(service, sheet_name):
     sheets = get_sheets(service, PRIZE_POINTS_SPREADSHEET_ID)
     sheet_names = [sheet['properties']['title'] for sheet in sheets]
     if sheet_name in sheet_names:
-        range = '{}!1:2'.format(sheet_name)
-        result = service.spreadsheets().values().get(
-            spreadsheetId=PRIZE_POINTS_SPREADSHEET_ID, range=range, majorDimension='COLUMNS').execute()
-        numLeagues = len(result.get('values', []))-4
-        range = '{}!A1:'.format(sheet_name)+xlsxwriter.utility.xl_col_to_name(numLeagues+4)
-        result = service.spreadsheets().values().get(
-            spreadsheetId=PRIZE_POINTS_SPREADSHEET_ID, range=range, majorDimension='ROWS').execute()
-        values = result.get('values', [])
-        if not numLeagues:
+        num_leagues_range = '{}!1:2'.format(sheet_name)
+        num_leagues_info = service.spreadsheets().values().get(
+            spreadsheetId=PRIZE_POINTS_SPREADSHEET_ID, range=num_leagues_range, majorDimension='COLUMNS').execute()
+        num_leagues = len(num_leagues_info.get('values', [])) - 4
+
+        prize_points_range = '{}!A1:'.format(sheet_name) + xlsxwriter.utility.xl_col_to_name(num_leagues + 4)
+        prize_points_info = service.spreadsheets().values().get(
+            spreadsheetId=PRIZE_POINTS_SPREADSHEET_ID, range=prize_points_range, majorDimension='ROWS').execute()
+        prize_points = prize_points_info.get('values', [])
+
+        if not num_leagues:
             print('No prize points found for this semester.')
         else:
             print('Prize points detected.\n')
-            return values, numLeagues
+            return prize_points, num_leagues
     else:
         print('No prize points found for this semester.')
         generate_prize_points_sheet(service, sheet_name)
     return None, 0
 
 def get_prize_points(service, prize_points_sheet_name):
-    prize_points, numLeagues = get_prize_points_sheet_info(service, prize_points_sheet_name)
-    prize_points_dict = defaultdict(dict)
-    points_used = {}
-    for i in range(1,numLeagues+1):
-        for j in range(1,len(prize_points)):
-            prize_points_dict[prize_points[0][3+i]][prize_points[j][0]] = prize_points[j][3+i]
-            points_used[prize_points[j][0]] = prize_points[j][2] if prize_points[j][2] != '' else 0
-    return prize_points_dict, points_used, numLeagues
+    prize_points, num_leagues = get_prize_points_sheet_info(service, prize_points_sheet_name)
+    prize_points_dict = defaultdict(dict) # this will look something like { '09-10-23': { 'Jonathan L': 6, 'Alex L': 8 } }
+    name_to_points_used_dict = {}
+
+    for col in range(1, num_leagues + 1):
+        for row in range(1, len(prize_points)):
+            league_date = prize_points[0][3 + col]
+            name = prize_points[row][0]
+            points = prize_points[row][3 + col]
+            points_used = prize_points[row][2]
+
+            prize_points_dict[league_date][name] = points
+            name_to_points_used_dict[name] = points_used if points_used != '' else 0
+
+    return prize_points_dict, name_to_points_used_dict, num_leagues
 
 def generate_prize_points_sheet(service, sheet_name):
     new_sheet_body = {


### PR DESCRIPTION
## Description
- Removed sorting (`self.group.sort_ratings(1)`) that occurs after rating has been adjusted by more than 50 points
- Fixed a bug where an out of bounds exception was thrown due to empty cells being present in the league prize point sheet. See image below:
   ![Screenshot 2023-11-01 at 7 02 17 PM](https://github.com/Lianathanoj/table-tennis-automation/assets/14138885/50eda663-8aec-44f6-a993-fb4378e62a5b)

- Miscellaneous fixes:
  - Edited the template UI to look more "balanced"
  - Cleaned up some minor syntax issues
  - Renamed some variables to be clearer
  - Modified or added clarifying comments

## Background
A synopsis of the issue can be found below. Let's say the following values were inputted into the script:

```
Please input the names and ratings for each person in Group 1.

Press tab to autocomplete names.
Name of person 1 in Group 1: Billy
Billy (1361) has been added to Group 1.

Name of person 2 in Group 1: Joe
Joe (1178) has been added to Group 1.

Name of person 3 in Group 1: Frank
Frank (1114) has been added to Group 1.

Name of person 4 in Group 1: Bob
Bob (1002) has been added to Group 1.

A: Billy (1361)
B: Joe (1178)
C: Frank (1114)
D: Bob (1002)

-  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -

Please input the game scores for Group 1.

For example, assuming B won 3 - 2 for Match B vs D, input 3:2.
In the case of B losing to D 2-3, input 2:3.

B versus D: 31
A versus C: 13
B versus C: 23
A versus D: 31
C versus D: 32
A versus B: 32
_______________________________________________________________________________
```

> The generated league sheet does not match what was entered into the automation script. As mentioned earlier, in the automation script, the players are assigned their letters based on their current rating in the roster. The matches won / lost for each player are assigned in this order within the sheet. However, in the auto generated league sheet, it appears that the player names and ratings are sorted with different letters, according to their adjusted rating. Because of this mismatch in sorting - the player names are sorted differently from the actual match data - the info generated in the sheet is incorrect. B&C are switched. Regardless of the switch of names / players, the sheet still treats player C as having won all matches, when in reality they only won one set. 

## Diagnosing the Fix
Code was added to do automatic rating adjustments if a player has had a rating change of at least 50 points per the USATT spec [here](https://usatt.simplycompete.com/info/ratings#:~:text=gained%20between%2050%20and). At this point, an additional sort based upon the rating adjustment, but this sort was actually extraneous and messed up the player order on the sheet. 

## Image Before the Fix
![Screenshot 2023-11-01 at 6 50 44 PM](https://github.com/Lianathanoj/table-tennis-automation/assets/14138885/52ad008e-334b-4f46-9898-f509bfc8679d)

## Image After the Fix
![Screenshot 2023-11-01 at 6 50 51 PM](https://github.com/Lianathanoj/table-tennis-automation/assets/14138885/67bd0f49-8af2-435f-95c3-f59b9c353f44)