### PR TITLE
fix(prize-points): revert conditional statement

### DIFF
--- a/google_sheets_functions.py
+++ b/google_sheets_functions.py
@@ -429,7 +429,7 @@ def get_prize_points(service, prize_points_sheet_name):
         for row in range(1, len(prize_points)):
             league_date = prize_points[0][3 + col]
             name = prize_points[row][0]
-            points = prize_points[row][3 + col] if len(prize_points[row]) < 3 + col else 0
+            points = prize_points[row][3 + col]
             points_used = prize_points[row][2]
 
             prize_points_dict[league_date][name] = points


### PR DESCRIPTION
## Description
In https://github.com/Lianathanoj/table-tennis-automation/pull/9, I implemented a fix for a sorting issue while also cleaning up some code. However, during clean up, I attempted to fix a bug where an out of bounds exception was thrown due to empty cells being present in the league prize point sheet, but the fix caused an issue which overwrote previous league point values to 0. On second look, the out of bounds exception should only occur if we add in names to the prize point sheet that are not present in the league roster, and this really shouldn't happen in the first place, or it can be manually fixed.

In order to manually fix the issue, we can add their names to the league roster document and manually fill in the cells below:
![image](https://github.com/Lianathanoj/table-tennis-automation/assets/14138885/a341d98d-e2e5-45a6-acf6-87e85024964c)

